### PR TITLE
Update rack because a security issue

### DIFF
--- a/images/api/Gemfile.lock
+++ b/images/api/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.1)
@@ -147,4 +147,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.16.1
+   1.17.1


### PR DESCRIPTION
[CVE-2018-16471 ](https://nvd.nist.gov/vuln/detail/CVE-2018-16471)
**Vulnerable versions**: >= 2.0.0, < 2.0.6
**Patched version**: 2.0.6
There is a possible XSS vulnerability in Rack before 2.0.6 and 1.6.11. Carefully crafted requests can impact the data returned by the scheme method on Rack::Request. Applications that expect the scheme to be limited to 'http' or 'https' and do not escape the return value could be vulnerable to an XSS attack. Note that applications using the normal escaping mechanisms provided by Rails may not be impacted, but applications that bypass the escaping mechanisms, or do not use them may be vulnerable.

[CVE-2018-16470](https://nvd.nist.gov/vuln/detail/CVE-2018-16470)
**Vulnerable versions**: >= 2.0.4, < 2.0.6
**Patched version**: 2.0.6
There is a possible DoS vulnerability in the multipart parser in Rack before 2.0.6. Specially crafted requests can cause the multipart parser to enter a pathological state, causing the parser to use CPU resources disproportionate to the request size.